### PR TITLE
Fix for mismatched keyboard accessory next/previous arrows

### DIFF
--- a/ExtraKit/ios/UIResponder.swift
+++ b/ExtraKit/ios/UIResponder.swift
@@ -65,12 +65,12 @@ public extension UIResponder {
 	func createPreviousNextDoneInputAccessory() {
 		guard let tf = self as? UITextInputTraits , previousNextDoneInputAccessory == nil else { return }
 
-		let segmentControl = UISegmentedControl(items: ["⌃","⌄"])
+		let segmentControl = UISegmentedControl(items: ["▲","▼"])
 		segmentControl.setTitleTextAttributes([
-			NSAttributedStringKey.font: UIFont.systemFont(ofSize: 40)
+			NSAttributedStringKey.font: UIFont.systemFont(ofSize: 20)
 		], for: .normal)
-		segmentControl.setContentOffset(CGSize(width:0, height: 9), forSegmentAt: 0)
-		segmentControl.setContentOffset(CGSize(width:0, height: -9), forSegmentAt: 1)
+		segmentControl.setContentOffset(CGSize(width:0, height: 0), forSegmentAt: 0)
+		segmentControl.setContentOffset(CGSize(width:0, height: 0), forSegmentAt: 1)
 
 		segmentControl.setWidth(50, forSegmentAt: 0)
 		segmentControl.setWidth(50, forSegmentAt: 1)


### PR DESCRIPTION
When using ExtraKit under iOS 12, the keyboard accessory arrows don't match:

![img_bec10523a8c4-1](https://user-images.githubusercontent.com/1564380/45514727-cfc55580-b76b-11e8-8025-2c36c8fb0b3c.jpeg)

This patch uses different characters and adjusts the font size and padding accordingly.

![img_778dbaaabbfa-1](https://user-images.githubusercontent.com/1564380/45514764-e8357000-b76b-11e8-8306-fa52020090ba.jpeg)
